### PR TITLE
Config for x64 App Service on Azure

### DIFF
--- a/VFatumbot.csproj
+++ b/VFatumbot.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'EmulatorDebug|AnyCPU' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/web.config
+++ b/web.config
@@ -4,7 +4,7 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="dotnet" arguments=".\VFatumbot.dll" stdoutLogEnabled="false" stdoutLogFile="\\?\%home%\LogFiles\stdout" />
+    <aspNetCore processPath="%ProgramFiles%\dotnet\dotnet" arguments=".\VFatumbot.dll" stdoutLogEnabled="true" stdoutLogFile="%home%\LogFiles\stdout.log" />
   </system.webServer>
 </configuration>
 <!--ProjectGuid: FDE8B63A-F28A-4A08-ACD9-6F45015F1848-->


### PR DESCRIPTION
Not the web.config updates seem to get overwritten when deploying so I manually added %ProgramFiles% so the 64-bit version of dotnet would be the runtime